### PR TITLE
Fix Transifex link in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ How to Contribute
 You can contribute using:
 
 - Github
-- `transifex <https://www.transifex.com/python-doc/public/>`_
+- `transifex <https://explore.transifex.com/python-doc/>`_
 - Or just by opening `an issue on github <https://github.com/python/python-docs-hi-infr/issues>`_
 
 


### PR DESCRIPTION
Updated Transifex link in the README.

 Possibly older outdated link, https://www.transifex.com/python-doc/public/
 
 Repalced by, if not incorrect,  https://explore.transifex.com/python-doc/